### PR TITLE
:sparkles: 홈 배너 UI, 더보기 무한스크롤 기능구현

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+import Link from 'next/link';
+import { COLOR } from '../../../../팀프로젝트/moss_version1/moss/src/constants';
+export const Banner = () => {
+  return (
+    <BannerPage>
+      <h2>Study with MOSS</h2>
+      <h3>모여라 스터디!</h3>
+      <div className="banner-des">
+        <p>혼자 공부하기 힘든 사람 모여라!</p>
+        <p>서로 서로자극이 되어 함께 성장해요!</p>
+      </div>
+      <Link href="/join" passHref>
+        <button>시작하기</button>
+      </Link>
+    </BannerPage>
+  );
+};
+
+const BannerPage = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 70px 0;
+  font-family: 'GmarketSansMedium';
+  h2 {
+    margin-bottom: 24px;
+    color: ${COLOR.main};
+    font-size: 32px;
+    font-weight: 700;
+  }
+  h3 {
+    margin-bottom: 24px;
+    font-size: 50px;
+    color: ${COLOR.black};
+  }
+  .banner-des {
+    font-family: 'Noto Sans KR';
+    line-height: 23px;
+    color: ${COLOR.deepGray};
+  }
+  button {
+    width: 260px;
+    height: 48px;
+    margin-top: 37px;
+    background-color: ${COLOR.main};
+    color: ${COLOR.white};
+  }
+`;

--- a/src/components/Scroll/InfiniteScroll.tsx
+++ b/src/components/Scroll/InfiniteScroll.tsx
@@ -1,0 +1,53 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import styled from '@emotion/styled';
+import { getPostList, postType } from './database';
+
+const InfiniteScroll = (): JSX.Element => {
+  const [page, setPage] = useState<number>(1);
+  const [posts, setPosts] = useState<postType[]>(getPostList(1));
+
+  const handleScroll = useCallback((): void => {
+    const { innerHeight } = window;
+    const { scrollHeight } = document.body;
+    const { scrollTop } = document.documentElement;
+
+    if (Math.round(scrollTop + innerHeight) >= scrollHeight) {
+      setPosts(posts.concat(getPostList(page + 1)));
+      setPage((prevPage: number) => prevPage + 1);
+    }
+  }, [page, posts]);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, true);
+    return () => {
+      window.removeEventListener('scroll', handleScroll, true);
+    };
+  }, [handleScroll]);
+
+  return (
+    <Container>
+      {posts.map((post: postType, idx: number) => (
+        <PostItem key={idx}>{post.contents}</PostItem>
+      ))}
+    </Container>
+  );
+};
+
+export default InfiniteScroll;
+
+const Container = styled.section`
+  width: 100%;
+  height: 30vh;
+  margin: 100px auto;
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+`;
+
+const PostItem = styled.div`
+  height: 250px;
+  padding: 16px;
+  border: 2px solid #eeeeee;
+  box-sizing: border-box;
+`;

--- a/src/components/Scroll/Scroll.tsx
+++ b/src/components/Scroll/Scroll.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+import { COLOR } from '../../constants';
+import { useState } from 'react';
+import InfiniteScroll from './infiniteScroll';
+
+export const Scroll = () => {
+  const [active, setActive] = useState(false);
+
+  function activeBtn() {
+    setActive(!active);
+  }
+
+  return (
+    <ScrollSection>
+      <button className="btn-more" onClick={activeBtn}>
+        더보기
+      </button>
+      {active ? <InfiniteScroll /> : null}
+    </ScrollSection>
+  );
+};
+const ScrollSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  .btn-more {
+    width: 120px;
+    height: 32px;
+    border-radius: 40px;
+    border: 1px solid ${COLOR.main};
+    font-size: 14px;
+    color: ${COLOR.main};
+  }
+`;

--- a/src/components/Scroll/database.ts
+++ b/src/components/Scroll/database.ts
@@ -1,0 +1,47 @@
+export type postType = {
+  page: number;
+  contents: string;
+};
+
+export const getPostList = (page: number): postType[] => {
+  return postList.filter((post: postType) => post.page === page);
+};
+
+export const postList: postType[] = [
+  {
+    page: 1,
+    contents: '첫번째 스터디',
+  },
+  {
+    page: 1,
+    contents: '두번째 스터디',
+  },
+  {
+    page: 1,
+    contents: '세번째 스터디',
+  },
+  {
+    page: 1,
+    contents: '네번째 스터디',
+  },
+  {
+    page: 2,
+    contents: '다섯번째 스터디',
+  },
+  {
+    page: 2,
+    contents: '여섯번째 스터디',
+  },
+  {
+    page: 2,
+    contents: '일곱번째 스터디',
+  },
+  {
+    page: 2,
+    contents: '여덟번째 스터디',
+  },
+  {
+    page: 3,
+    contents: '아홉번째 스터디',
+  },
+];

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,58 +1,61 @@
 import type { NextPage } from 'next';
 import styled from '@emotion/styled';
-
+import { Banner } from '../components/Banner';
 import { TitleSearch } from '../components/TitleSearch';
 import { StudyCard } from '../components/StudyCard';
+import { Scroll } from '../components/Scroll/Scroll';
 
 const Home: NextPage = () => {
   return (
     <>
+      <Banner />
       <TitleSearch />
       <StudyList>
         <StudyCard
-          category = '카테고리'
-          title = 'React 강의 듣기'
-          hashtag = '#리액트 #프론트엔드'
-          member = {1}
-          link = '#'
+          category="카테고리"
+          title="React 강의 듣기"
+          hashtag="#리액트 #프론트엔드"
+          member={1}
+          link="#"
         />
         <StudyCard
-          category = '카테고리'
-          title = 'React 강의 듣기'
-          hashtag = '#리액트 #프론트엔드'
-          member = {1}
-          link = '#'
+          category="카테고리"
+          title="React 강의 듣기"
+          hashtag="#리액트 #프론트엔드"
+          member={1}
+          link="#"
         />
         <StudyCard
-          category = '카테고리'
-          title = 'React 강의 듣기'
-          hashtag = '#리액트 #프론트엔드'
-          member = {1}
-          link = '#'
+          category="카테고리"
+          title="React 강의 듣기"
+          hashtag="#리액트 #프론트엔드"
+          member={1}
+          link="#"
         />
         <StudyCard
-          category = '카테고리'
-          title = 'React 강의 듣기'
-          hashtag = '#리액트 #프론트엔드'
-          member = {1}
-          link = '#'
+          category="카테고리"
+          title="React 강의 듣기"
+          hashtag="#리액트 #프론트엔드"
+          member={1}
+          link="#"
         />
         <StudyCard
-          category = '카테고리'
-          title = 'React 강의 듣기'
-          hashtag = '#리액트 #프론트엔드'
-          member = {1}
-          link = '#'
+          category="카테고리"
+          title="React 강의 듣기"
+          hashtag="#리액트 #프론트엔드"
+          member={1}
+          link="#"
         />
       </StudyList>
-    </>  
+      <Scroll />
+    </>
   );
 };
 
 const StudyList = styled.section`
-display: grid;
-grid-template-columns: repeat(4, 1fr);
-gap: 20px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
 `;
 
 export default Home;


### PR DESCRIPTION
# 📘 PR 컨벤션 

## 수정 사항 요약 📍
- 홈 배너 화면 구현
- 더보기 무한 스크롤 구현

## 수정 사항 구체적인 설명
- 홈 화면 배너 화면 구현: 시작하기 클릭하면 현재는 join화면으로 연결
- 더보기 클릭하면 4개씩 새로 업로드 되도록 구현

## 스크린샷 (기능 구현 시) 📸
<img width="725" alt="스크린샷 2022-03-15 오후 6 40 12" src="https://user-images.githubusercontent.com/93498523/158349890-694ed68c-9a51-4586-a4e3-c868fbc10f02.png">

<img width="1239" alt="스크린샷 2022-03-15 오후 6 40 29" src="https://user-images.githubusercontent.com/93498523/158349922-21ae76bd-3da8-4bc6-925c-c6edfe662686.png">


## 기타 질문 🙋🏻
- 백이 완료되면 스크롤 불러 오는거는 다시 정리해야 합니다. 
- login이 없어서 우선 join으로 배너 링크 연결해두었습니다.

## 체크 리스트 ✅
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.