### PR TITLE
Header, Footer, Home 반응형 스타일 추가 

### DIFF
--- a/src/components/Join/Join.tsx
+++ b/src/components/Join/Join.tsx
@@ -179,6 +179,9 @@ export const JoinPage = () => {
 const Container = styled.section`
   margin: 100px auto 0;
   max-width: 340px;
+  @media (max-width: 440px) {
+    margin: 60px auto 0;
+  }
 `;
 
 const Title = styled.h2`

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -83,4 +83,17 @@ const Search = styled.form`
     border: 0;
     padding: 0;
   }
+  @media (max-width: 440px) {
+    input {
+      position: absolute;
+      clip: rect(0, 0, 0, 0);
+      width: 1px;
+      height: 1px;
+      position: absolute;
+    }
+    button {
+      background: ${COLOR.main} url(/images/search_white.svg) no-repeat 50% 50% /
+        60%;
+    }
+  }
 `;

--- a/src/components/TitleSearch.tsx
+++ b/src/components/TitleSearch.tsx
@@ -29,4 +29,9 @@ const Wrap = styled.div`
       vertical-align: -0.1em;
     }
   }
+  @media (max-width: 440px) {
+    h2 {
+      width: 100%;
+    }
+  }
 `;

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -18,4 +18,9 @@ const Container = styled.section`
   width: 1224px;
   max-width: calc(100% - 60px);
   margin: 0 auto 80px auto;
+
+  @media (max-width: 440px) {
+    width: 100%;
+    scrollbar-width: none;
+  }
 `;

--- a/src/components/layouts/partials/Footer.tsx
+++ b/src/components/layouts/partials/Footer.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { COLOR } from '../../../constants';
 
 export const Footer = () => {
   return (
@@ -32,7 +33,14 @@ export const Footer = () => {
     </FooterCont>
   );
 };
+
+// 반응형 컴포넌트 대기?
+// const breakpoints = [390, 1440];
+
+// const mq = breakpoints.map((bp) => `@media (min-width: ${bp}px)`);
+
 const FooterCont = styled.footer`
+  height: 100px;
   padding: 0 100px;
   margin-top: 10vh;
   section {
@@ -42,6 +50,39 @@ const FooterCont = styled.footer`
     align-items: center;
     border-top: 1px solid #c4c4c4;
   }
+  @media (max-width: 440px) {
+    position: relative;
+    margin-top: 0;
+    height: fit-content;
+    padding: 0;
+    &::before {
+      content: '';
+      display: block;
+      position: absolute;
+      top: -28px;
+      right: 28px;
+      width: 48px;
+      height: 48px;
+      border: 1px solid ${COLOR.point};
+      border-radius: 50%;
+      background: ${COLOR.white};
+    }
+    &::after {
+      content: '';
+      display: block;
+      position: absolute;
+      top: -7px;
+      right: 46px;
+      border: 1px solid ${COLOR.black};
+      border-width: 0 0 2px 2px;
+      width: 10px;
+      height: 10px;
+      transform: rotate(135deg);
+    }
+    section {
+      padding: 1.5rem 1.5rem;
+    }
+  } ;
 `;
 
 const FooterLogo = styled.div`
@@ -62,5 +103,10 @@ const MemberList = styled.ul`
   li > small {
     color: #666666;
     font-size: 14px;
+  }
+  @media (max-width: 440px) {
+    display: grid;
+    grid: repeat(2, 20px) / auto-flow 45px;
+    width: calc(100% / 2.3);
   }
 `;

--- a/src/components/layouts/partials/Header.tsx
+++ b/src/components/layouts/partials/Header.tsx
@@ -4,64 +4,90 @@ import Link from 'next/link';
 export const Header = () => {
   return (
     <HeaderCont>
-      <section>
-        <article>
-          <button>
-            <Link href="/">
-              <img src="/images/header_logo.svg" alt="헤더로고" />
-            </Link>
-          </button>
-          <h1>모여라 스터디</h1>
-        </article>
-        <article>
-          <Link href="/join">
-            <button>회원가입</button>
+      <LeftHeader>
+        <button>
+          <Link href="/">
+            <Logo src="/images/header_logo.svg" alt="헤더로고" />
           </Link>
-          <Link href="/login">
-            <button>로그인</button>
-          </Link>
-        </article>
-      </section>
+        </button>
+        <h1>모여라 스터디</h1>
+      </LeftHeader>
+      <RightHeader>
+        <Link href="/join">
+          <button>회원가입</button>
+        </Link>
+        <Link href="/login">
+          <button>로그인</button>
+        </Link>
+      </RightHeader>
+      <Link href="/join">
+        <Mypage src="images/login.svg" alt="로그인 아이콘" />
+      </Link>
     </HeaderCont>
   );
 };
 const HeaderCont = styled.header`
   display: flex;
-  padding: 0 100px;
+  padding: 0 2.5rem;
   height: 100px;
-  section {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    article {
-      &:nth-of-type(1) {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        img {
-          width: 124px;
-          height: 32px;
-        }
-        h1 {
-          font-weight: 400;
-        }
-      }
-      &:nth-of-type(2) {
-        display: flex;
-        gap: 8px;
-        button {
-          border: 1px solid #e7e6e2;
-          padding: 9px 20px;
-          width: 100px;
-          font-size: 14px;
-          line-height: 14px;
-          &:nth-child(2) {
-            border: 1px solid #34c88a;
-            color: #34c88a;
-          }
-        }
-      }
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  @media (max-width: 440px) {
+    height: 60px;
+    padding: 0 1rem;
+  } ;
+`;
+
+const LeftHeader = styled.article`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  h1 {
+    font-weight: 400;
+  }
+  @media (max-width: 440px) {
+    h1 {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      clip: rect(0 0 0 0);
+      overflow: hidden;
     }
+  }
+`;
+
+const RightHeader = styled.article`
+  display: flex;
+  gap: 8px;
+  button {
+    border: 1px solid #e7e6e2;
+    padding: 9px 20px;
+    width: 100px;
+    font-size: 14px;
+    line-height: 14px;
+    &:nth-child(1) {
+      border: 1px solid #34c88a;
+      color: #34c88a;
+    }
+  }
+  @media (max-width: 440px) {
+    display: none;
+  }
+`;
+const Logo = styled.img`
+  width: 10rem;
+  height: 32px;
+  @media (max-width: 440px) {
+    width: 6rem;
+  }
+`;
+
+const Mypage = styled.img`
+  display: none;
+  @media (max-width: 440px) {
+    display: block;
+    width: 2rem;
   }
 `;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -56,6 +56,10 @@ const StudyList = styled.section`
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 20px;
+  @media (max-width: 440px) {
+    grid-template-columns: repeat(1, 1fr);
+    margin: 0 0 20px;
+  }
 `;
 
 export default Home;


### PR DESCRIPTION
## 수정 사항 요약 📍
Header, Footer, Home 반응형 스타일 추가 

## 수정 사항 구체적인 설명
`@media (max-width: 440px)`에 맞춰 반응형 스타일 추가 했습니다.
피그마 UI에 따른 디자인 변경했습니다.

## 스크린샷 (기능 구현 시) 📸
<img width="310" alt="image" src="https://user-images.githubusercontent.com/61954107/159166839-c4874208-d533-4328-b2f0-629e2f05cac3.png">

<img width="314" alt="image" src="https://user-images.githubusercontent.com/61954107/159166894-4fb90285-4df4-443c-a833-f05edd5e4939.png">

<img width="317" alt="image" src="https://user-images.githubusercontent.com/61954107/159166909-6d1491df-25c3-40f3-b2e8-9fc3abfaec66.png">


## 체크 리스트 ✅

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.