### PR TITLE
:lipstick: 전체적인 UI 수정

### DIFF
--- a/client/src/components/JoinStudy/JoinStudyModal.tsx
+++ b/client/src/components/JoinStudy/JoinStudyModal.tsx
@@ -35,7 +35,7 @@ export const JoinStudyModal = ({ modal, setModal }: IModal) => {
         <animated.div style={animation}>
           <Container>
             <Button onClick={() => setModal((prev: boolean) => !prev)}>
-              <Img src="./images/icons/close.png"></Img>
+              <Img src="/images/icons/close.png"></Img>
             </Button>
             <h1>
               <div>스터디 신청</div>

--- a/client/src/components/JoinStudy/JoinStudyModal.tsx
+++ b/client/src/components/JoinStudy/JoinStudyModal.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { COLOR } from '../../constants';
 import { useSpring, animated } from 'react-spring';
+import { useState } from 'react';
 
 interface IModal {
   modal: boolean;
@@ -15,27 +16,53 @@ export const JoinStudyModal = ({ modal, setModal }: IModal) => {
     opacity: modal ? 1 : 0,
     transfrom: modal ? `translateY(0%)` : `translateY(-100%)`,
   });
+  const [goal, setGoal] = useState('');
+  const [reason, setReason] = useState('');
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { name, value },
+    } = e;
+    if (name === 'goal') {
+      setGoal(e.target.value);
+    } else if (name === 'reason') {
+      setReason(e.target.value);
+    }
+  };
   return (
     <>
       {modal ? (
         <animated.div style={animation}>
           <Container>
-            <button onClick={() => setModal((prev: boolean) => !prev)}>
-              ❌
-            </button>
+            <Button onClick={() => setModal((prev: boolean) => !prev)}>
+              <Img src="./images/icons/close.png"></Img>
+            </Button>
             <h1>
-              <div>로그인</div>
+              <div>스터디 신청</div>
             </h1>
             <form action="">
               <div>
                 <label htmlFor="goal">각오한마디</label>
-                <input id="goal" type="text" placeholder="placeholder" />
+                <input
+                  name="goal"
+                  id="goal"
+                  type="text"
+                  onChange={onChange}
+                  placeholder="placeholder"
+                />
               </div>
               <div>
                 <label htmlFor="reason">참여목적</label>
-                <textarea id="reason" type="text" placeholder="placeholder" />
+                <textarea
+                  name="reason"
+                  id="reason"
+                  onChange={onChange}
+                  placeholder="placeholder"
+                />
               </div>
-              <button>스터디 신청</button>
+              <button className="apply-btn" disabled={!(goal && reason)}>
+                스터디 신청
+              </button>
             </form>
           </Container>
         </animated.div>
@@ -58,14 +85,6 @@ const Container = styled.section`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  button {
-    &:nth-child(1) {
-      border: none;
-      position: absolute;
-      top: 20px;
-      right: 20px;
-    }
-  }
   h1 {
     width: 60px;
     border-bottom: 4px solid #34c88a;
@@ -125,13 +144,25 @@ const Container = styled.section`
         }
       }
     }
-    button {
+    .apply-btn {
       margin-top: 12px;
-      background-color: ${COLOR.gray};
-      color: ${COLOR.grayText};
+      background-color: ${COLOR.main};
+      color: #fff;
       font-size: 16px;
       width: 100%;
       padding: 17px 0;
     }
+    &:disabled {
+      background-color: ${COLOR.gray};
+      color: ${COLOR.grayText};
+    }
   }
 `;
+
+const Button = styled.button`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+`;
+
+const Img = styled.img``;

--- a/client/src/components/StudyMain/Container.tsx
+++ b/client/src/components/StudyMain/Container.tsx
@@ -1,19 +1,50 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
 import { Member } from './Member';
 import { Notice } from './Notice';
 import { Record } from './Record';
 import { TodoList } from './Todo';
 
 export const StudyComponents = () => {
+  const [token, setToken] = useState(false);
+  useEffect(() => {
+    const Token = localStorage.getItem('Token');
+    if (Token) {
+      getToken(`${Token}`);
+    }
+  });
+  const getToken = (Token: string) => {
+    setToken(true);
+    console.log(Token);
+  };
   return (
     <>
-      <Container>
-        <Record />
-        <TodoList />
-        <Notice />
-        <Member />
-      </Container>
+      {token ? (
+        <Container>
+          <Record />
+          <TodoList />
+          <Notice />
+          <Member />
+        </Container>
+      ) : (
+        <>
+          <Link href="/login" passHref>
+            <Button>
+              <Img src="/images/header_logo.svg" alt="로고" />
+              <p>스터디원이 되어야 상세 정보를 볼 수 있어요!</p>
+            </Button>
+          </Link>
+          <Blur>
+            <Container>
+              <Record />
+              <TodoList />
+              <Notice />
+              <Member />
+            </Container>
+          </Blur>
+        </>
+      )}
     </>
   );
 };
@@ -23,3 +54,30 @@ const Container = styled.div`
   justify-content: space-between;
   flex-wrap: wrap;
 `;
+
+const Blur = styled.div`
+  filter: blur(8px);
+  position: relative;
+`;
+
+const Button = styled.button`
+  position: absolute;
+  bottom: 100px;
+  right: 40%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  width: 290px;
+  height: 290px;
+  padding: 44px;
+  box-sizing: border-box;
+  z-index: 10;
+  background: #ffffff;
+  box-shadow: 5px 5px 30px rgba(0, 0, 0, 0.08);
+  border-radius: 100%;
+  font-size: 18px;
+`;
+
+const Img = styled.img``;

--- a/client/src/components/StudyMain/StudyBanner.tsx
+++ b/client/src/components/StudyMain/StudyBanner.tsx
@@ -42,6 +42,7 @@ const Banner = styled.section`
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
+  position: relative;
   background: url('/images/background.png');
   background-size: cover;
   padding: 24px 0 24px 24px;
@@ -133,6 +134,8 @@ const StudyBtn = styled.a`
 const Hashtag = styled.div`
   margin-right: 32px;
   padding: 3px 10px;
+  position: absolute;
+  right: 0;
   background-color: #fff;
   color: #767676;
   font-size: 14px;

--- a/client/src/components/layouts/partials/Footer.tsx
+++ b/client/src/components/layouts/partials/Footer.tsx
@@ -40,8 +40,8 @@ export const Footer = () => {
 // const mq = breakpoints.map((bp) => `@media (min-width: ${bp}px)`);
 
 const FooterCont = styled.footer`
+  width: 100vw;
   height: 100px;
-
   margin-top: 10vh;
   section {
     padding: 16px 0;

--- a/client/src/components/layouts/partials/Header.tsx
+++ b/client/src/components/layouts/partials/Header.tsx
@@ -1,8 +1,20 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
+import { useState, useEffect } from 'react';
 import { COLOR } from '../../../constants';
 
 export const Header = () => {
+  const [token, setToken] = useState(false);
+  useEffect(() => {
+    const Token = localStorage.getItem('Token');
+    if (Token) {
+      getToken(`${Token}`);
+    }
+  });
+  const getToken = (Token: string) => {
+    setToken(true);
+    console.log(Token);
+  };
   return (
     <HeaderCont className="max-width">
       <div className="left">
@@ -16,19 +28,26 @@ export const Header = () => {
         </Link>
       </div>
       <div className="right">
-        <Link href="/join" passHref>
-          <a className="join">회원가입</a>
-        </Link>
-        <Link href="/login" passHref>
-          <a className="login">로그인</a>
-        </Link>
-        {/* 로그인시에만  */}
-        {/* <Link href="/my-page" passHref>
-          <a className="mypage">마이페이지</a>
-        </Link>
-        <Link href="/" passHref>
-          <a className="logout">로그아웃</a>
-        </Link> */}
+        {token ? (
+          <>
+            <Link href="/my-page" passHref>
+              <a className="mypage">마이페이지</a>
+            </Link>
+            <Link href="/" passHref>
+              <a className="logout">로그아웃</a>
+            </Link>
+          </>
+        ) : (
+          <>
+            <Link href="/join" passHref>
+              <a className="join">회원가입</a>
+            </Link>
+
+            <Link href="/login" passHref>
+              <a className="login">로그인</a>
+            </Link>
+          </>
+        )}
       </div>
       <Link href="/join" passHref>
         <Mypage src="images/login.svg" alt="로그인 아이콘" />

--- a/client/src/pages/study/index.tsx
+++ b/client/src/pages/study/index.tsx
@@ -5,6 +5,7 @@ import { Notice } from '../../components/StudyMain/Notice';
 import { Record } from '../../components/StudyMain/Record';
 import { TodoList } from '../../components/StudyMain/Todo';
 import { StudyComponents } from '../../components/StudyMain/Container';
+import { useState } from 'react';
 
 export default function StudyPage() {
   return (


### PR DESCRIPTION
## 수정 사항 요약 📍
- 스터디 페이지 블러 처리
- 헤더 로그인 여부에 따라 다르게 표현
- 스터디 신청 모달 수정
- 스터디 배너 수정
-  푸터 width값 수정
-  엑박뜨는 이미지 경로 수정

## 수정 사항 구체적인 설명
- 스터디 페이지는 토큰값이 있으면 다 보이고, 없으면 블러처리되게 구현
- 헤더 부분도 토큰값이 있으면 마이페이지, 로그아웃이 보이고, 없으면 로그인, 회원가입이 보이게 수정
- 스터디 모달 부분 수정
    - 로그인 글귀 -> 스터디 신청으로 변결
    - 클로즈 버튼 이미지로 수정
    - 둘다 작성해야 버튼 활성화 되도록 수정
- 스터디 배너 모달창이 열려도 가만히 있게 수정
- 푸터 width값 헤더에 맞춰 100vw로 수정


## 스크린샷 (기능 구현 시) 📸

<img width="1412" alt="스크린샷 2022-03-30 오후 11 25 20" src="https://user-images.githubusercontent.com/93498523/160858391-f992bf15-2443-486a-9fb4-d46cd0a83515.png">
<img width="1426" alt="스크린샷 2022-03-30 오후 11 25 32" src="https://user-images.githubusercontent.com/93498523/160858405-999b83e9-9596-4805-ac7e-80cb4bf0d448.png">


## 기타 질문 🙋🏻


## 체크 리스트 ✅
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.